### PR TITLE
DATA-1000: Update parse login response (missed tags)

### DIFF
--- a/rets/http/parsers/parse.py
+++ b/rets/http/parsers/parse.py
@@ -64,9 +64,14 @@ def parse_capability_urls(response: Response) -> dict:
     """
     elem = parse_xml(response)
     response_elem = elem.find('RETS-RESPONSE')
+    raw_arguments = None
     if response_elem is None:
-        return {}
-    raw_arguments = response_elem.text.strip().split('\n')
+        if elem.text:
+            raw_arguments = elem.text.strip().split('\n')
+        else:
+            return {}
+    else:
+        raw_arguments = response_elem.text.strip().split('\n')
     return dict((s.strip() for s in arg.split('=', 1)) for arg in raw_arguments)
 
 


### PR DESCRIPTION
[DATA-1000: Update parse login response (missed tags)](https://github.com/luxurypresence/rets/commit/fdc64992bddcad4c70504b93e1e457e8ebbdfd76)

For some rets feeds the login response (containing basic urls & server info) is malformed - some xml tags are missed - adding workaround to handle such services (bahams mls e.g.)