### PR TITLE
DATA-1377: Hotfix more unexpected characters in getObject response for media description his_his

### DIFF
--- a/rets/http/parsers/parse_object.py
+++ b/rets/http/parsers/parse_object.py
@@ -18,7 +18,7 @@ class CustomBodyPart(BodyPart):
         if b'\r\n\r\n' in content or b'\r\n' in content:
             first, self.content = _split_on_find(content, b'\r\n\r\n')
             if first != b'':
-                headers = _header_parser(re.sub(b'([^\r])\n', b' ', first.lstrip()), encoding)
+                headers = _header_parser(re.sub(b'([^\r])[\n]+', b' ', first.lstrip()), encoding)
         else:
             raise ImproperBodyPartContentException(
                 'content does not contain CR-LF-CR-LF'


### PR DESCRIPTION
One more hotfix for rets lib to bypass unexpected format of the getObject response for media query in his_his feed. See [DATA-1377] for details.

[DATA-1377]: https://luxurypresence.atlassian.net/browse/DATA-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ